### PR TITLE
Refactor notification handler logic

### DIFF
--- a/src/modules/notifications/application/commands/handlers/send-notification.handler.ts
+++ b/src/modules/notifications/application/commands/handlers/send-notification.handler.ts
@@ -2,17 +2,9 @@ import { HttpStatus, Injectable } from '@nestjs/common';
 import { CommandHandler, EventBus, ICommandHandler } from '@nestjs/cqrs';
 import { SendNotificationCommand } from '../send-notification.command';
 import { SendNotificationOutputDTO } from '../../ports/in/send-notification.port';
-import { Notification } from '@modules/notifications/domain/aggregates/notification.aggregate';
-import { ID, Result } from '@inpro-labs/core';
-import { NotificationChannel } from '@modules/notifications/domain/enums/notification-channel.enum';
-import { NotificationStatus } from '@modules/notifications/domain/enums/notification-status.enum';
 import { BusinessException } from '@shared/exceptions/business.exception';
-import { EmailChannelData } from '@modules/notifications/domain/value-objects/email-channel-data.value-object';
-import { SmsChannelData } from '@modules/notifications/domain/value-objects/sms-channel-data.value-object';
-import { TemplateManagerService } from '@modules/notifications/infra/services/template-manager.service';
-import { INotificationRepository } from '@modules/notifications/domain/interfaces/repositories/notification.repository';
 import { QueueNotificationEvent } from '@modules/notifications/domain/events/queue-notification.event';
-import { PlaceholderSensitivity } from '@modules/notifications/domain/enums/placeholder-sensitivity.enum';
+import { CreateNotificationService } from '../../services/create-notification.service';
 
 @Injectable()
 @CommandHandler(SendNotificationCommand)
@@ -20,124 +12,46 @@ export class SendNotificationHandler
   implements ICommandHandler<SendNotificationCommand, SendNotificationOutputDTO>
 {
   constructor(
-    private readonly templateManagerService: TemplateManagerService,
-    private readonly notificationRepository: INotificationRepository,
+    private readonly createNotificationService: CreateNotificationService,
     private readonly eventBus: EventBus,
   ) {}
 
   async execute(
     command: SendNotificationCommand,
   ): Promise<SendNotificationOutputDTO> {
-    const { userId, templateId, templateVariables, channel, channelData } =
-      command.dto;
+    const result = await this.createNotificationService.execute(command.dto);
 
-    if (!Object.values(NotificationChannel).includes(channel)) {
-      throw new BusinessException(
-        `Invalid channel: ${channel}`,
-        'INVALID_NOTIFICATION_CHANNEL',
-        HttpStatus.BAD_REQUEST,
-      );
+    if (result.isErr()) {
+      const code = result.getErr()!.message;
+      let status = HttpStatus.BAD_REQUEST;
+      let message = 'Failed to create notification';
+
+      switch (code) {
+        case 'INVALID_NOTIFICATION_CHANNEL':
+          message = `Invalid channel: ${command.dto.channel}`;
+          break;
+        case 'NOTIFICATION_TEMPLATE_NOT_FOUND':
+          message = 'Template not found';
+          status = HttpStatus.NOT_FOUND;
+          break;
+        case 'NOTIFICATION_CHANNEL_NOT_AVAILABLE':
+          message = 'Channel not available for template';
+          break;
+        case 'INVALID_TEMPLATE_VARIABLES':
+          message = 'Invalid template variables';
+          break;
+        case 'NOTIFICATION_CREATION_ERROR':
+        default:
+          break;
+      }
+
+      throw new BusinessException(message, code, status);
     }
 
-    const templateResult = this.templateManagerService.getTemplate(templateId);
-
-    if (templateResult.isErr()) {
-      throw new BusinessException(
-        'Template not found',
-        'NOTIFICATION_TEMPLATE_NOT_FOUND',
-        HttpStatus.NOT_FOUND,
-      );
-    }
-
-    const template = templateResult.unwrap();
-
-    if (!template.isChannelAvailable(channel)) {
-      throw new BusinessException(
-        `Channel-${channel} not available for template ${template.get('name')}`,
-        'NOTIFICATION_CHANNEL_NOT_AVAILABLE',
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-
-    let notificationResult: Result<Notification, Error> | undefined;
-
-    const redactedTemplateVariables = {
-      ...templateVariables,
-      ...template
-        .getChannel(channel)
-        .unwrap()
-        .placeholders.reduce(
-          (acc, field) => {
-            const isSecure =
-              field.get('sensitivity') === PlaceholderSensitivity.SECURE;
-
-            if (isSecure) {
-              acc[field.get('name')] = '**redacted**';
-            }
-
-            return acc;
-          },
-          {} as Record<string, string>,
-        ),
-    };
-
-    if (channel === NotificationChannel.EMAIL) {
-      const emailChannelData = EmailChannelData.create({
-        to: channelData.to as string,
-      }).unwrap();
-
-      notificationResult = Notification.create({
-        channel: NotificationChannel.EMAIL,
-        channelData: emailChannelData,
-        userId: ID.create(userId).unwrap(),
-        template,
-        status: NotificationStatus.PENDING,
-        attempts: 0,
-        templateVariables: redactedTemplateVariables,
-      });
-    }
-
-    if (channel === NotificationChannel.SMS) {
-      const smsChannelData = SmsChannelData.create({
-        phone: channelData.phone as string,
-      }).unwrap();
-
-      notificationResult = Notification.create({
-        channel: NotificationChannel.SMS,
-        channelData: smsChannelData,
-        userId: ID.create(userId).unwrap(),
-        template,
-        status: NotificationStatus.PENDING,
-        attempts: 0,
-        templateVariables: redactedTemplateVariables,
-      });
-    }
-
-    if (notificationResult?.isErr()) {
-      throw new BusinessException(
-        notificationResult.getErr()!.message,
-        'NOTIFICATION_CREATION_ERROR',
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-
-    const notification = notificationResult!.unwrap();
-    const isVariablesValid = notification
-      .get('template')
-      .validateData(channel, templateVariables);
-
-    if (isVariablesValid.isErr()) {
-      throw new BusinessException(
-        isVariablesValid.getErr()!.message,
-        'INVALID_TEMPLATE_VARIABLES',
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-
-    await this.notificationRepository.save(notification);
+    const notification = result.unwrap();
 
     this.eventBus.publish(
-      new QueueNotificationEvent(notification, templateVariables),
+      new QueueNotificationEvent(notification, command.dto.templateVariables),
     );
 
     return notification;

--- a/src/modules/notifications/application/services/create-notification.service.ts
+++ b/src/modules/notifications/application/services/create-notification.service.ts
@@ -1,0 +1,110 @@
+import { Injectable } from '@nestjs/common';
+import { Err, Ok, Result, ID } from '@inpro-labs/core';
+import { SendNotificationInputDTO } from '../ports/in/send-notification.port';
+import { INotificationRepository } from '../../domain/interfaces/repositories/notification.repository';
+import { NotificationChannel } from '../../domain/enums/notification-channel.enum';
+import { NotificationStatus } from '../../domain/enums/notification-status.enum';
+import { Notification } from '../../domain/aggregates/notification.aggregate';
+import { EmailChannelData } from '../../domain/value-objects/email-channel-data.value-object';
+import { SmsChannelData } from '../../domain/value-objects/sms-channel-data.value-object';
+import { PlaceholderSensitivity } from '../../domain/enums/placeholder-sensitivity.enum';
+
+@Injectable()
+export class CreateNotificationService {
+  constructor(private readonly notificationRepository: INotificationRepository) {}
+
+  async execute(
+    dto: SendNotificationInputDTO,
+  ): Promise<Result<Notification, Error>> {
+    const { userId, templateId, templateVariables, channel, channelData } = dto;
+
+    if (!Object.values(NotificationChannel).includes(channel)) {
+      return Err(new Error('INVALID_NOTIFICATION_CHANNEL'));
+    }
+
+    const templateResult = this.notificationRepository.getNotificationTemplate(
+      templateId,
+    );
+
+    if (templateResult.isErr()) {
+      return Err(new Error('NOTIFICATION_TEMPLATE_NOT_FOUND'));
+    }
+
+    const template = templateResult.unwrap();
+
+    if (!template.isChannelAvailable(channel)) {
+      return Err(new Error('NOTIFICATION_CHANNEL_NOT_AVAILABLE'));
+    }
+
+    const redactedTemplateVariables = {
+      ...templateVariables,
+      ...template
+        .getChannel(channel)
+        .unwrap()
+        .placeholders.reduce((acc, field) => {
+          const isSecure =
+            field.get('sensitivity') === PlaceholderSensitivity.SECURE;
+          if (isSecure) {
+            acc[field.get('name')] = '**redacted**';
+          }
+          return acc;
+        }, {} as Record<string, string>),
+    };
+
+    let notificationResult: Result<Notification, Error>;
+
+    if (channel === NotificationChannel.EMAIL) {
+      const emailChannelData = EmailChannelData.create({
+        to: channelData.to as string,
+      }).unwrap();
+
+      notificationResult = Notification.create({
+        channel: NotificationChannel.EMAIL,
+        channelData: emailChannelData,
+        userId: ID.create(userId).unwrap(),
+        template,
+        status: NotificationStatus.PENDING,
+        attempts: 0,
+        templateVariables: redactedTemplateVariables,
+      });
+    } else if (channel === NotificationChannel.SMS) {
+      const smsChannelData = SmsChannelData.create({
+        phone: channelData.phone as string,
+      }).unwrap();
+
+      notificationResult = Notification.create({
+        channel: NotificationChannel.SMS,
+        channelData: smsChannelData,
+        userId: ID.create(userId).unwrap(),
+        template,
+        status: NotificationStatus.PENDING,
+        attempts: 0,
+        templateVariables: redactedTemplateVariables,
+      });
+    } else {
+      return Err(new Error('INVALID_NOTIFICATION_CHANNEL'));
+    }
+
+    if (notificationResult.isErr()) {
+      return Err(notificationResult.getErr()!);
+    }
+
+    const notification = notificationResult.unwrap();
+
+    const variablesValid = notification
+      .get('template')
+      .validateData(channel, templateVariables);
+
+    if (variablesValid.isErr()) {
+      return Err(new Error('INVALID_TEMPLATE_VARIABLES'));
+    }
+
+    const saveResult = await this.notificationRepository.save(notification);
+
+    if (saveResult.isErr()) {
+      return Err(new Error('NOTIFICATION_CREATION_ERROR'));
+    }
+
+    return Ok(notification);
+  }
+}

--- a/src/modules/notifications/notification.module.ts
+++ b/src/modules/notifications/notification.module.ts
@@ -15,6 +15,7 @@ import { MailSenderGateway } from '@shared/gateways/mail/mail-sender.gateway';
 import { notificationQueueServiceProvider } from './infra/nest/providers/notification-queue.service.provider';
 import { notificationSenderServiceProvider } from './infra/nest/providers/notification-sender.service.provider';
 import { notificationRepositoryProvider } from './infra/nest/providers/notification.repository.provider';
+import { CreateNotificationService } from './application/services/create-notification.service';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { notificationRepositoryProvider } from './infra/nest/providers/notificat
   controllers: [SendNotificationController],
   providers: [
     SendNotificationHandler,
+    CreateNotificationService,
     TemplateManagerService,
     QueueNotificationEventHandler,
     NotificationProcessor,


### PR DESCRIPTION
## Summary
- delegate notification creation to `CreateNotificationService`
- use new service in `SendNotificationHandler`
- register service in `NotificationModule`

## Testing
- `pnpm test` *(fails: dotenv not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc723b9b4832bb683a4a6803d1985